### PR TITLE
Fix error: add pcl lib to target_link_libraries

### DIFF
--- a/perception_aware_planner/exploration_manager/CMakeLists.txt
+++ b/perception_aware_planner/exploration_manager/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL 1.7 REQUIRED)
+find_package(PCL REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -34,6 +34,9 @@ include_directories(
   ${PCL_INCLUDE_DIRS}
 )
 
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
 add_executable(exploration_node
   src/exploration_node.cpp 
   src/perception_aware_exploration_fsm.cpp
@@ -42,5 +45,6 @@ add_executable(exploration_node
   )
 target_link_libraries(exploration_node 
   ${catkin_LIBRARIES}
+  # ${PCL_LIBRARIES}
   # -ldw
   )

--- a/perception_aware_planner/exploration_manager/CMakeLists.txt
+++ b/perception_aware_planner/exploration_manager/CMakeLists.txt
@@ -45,6 +45,6 @@ add_executable(exploration_node
   )
 target_link_libraries(exploration_node 
   ${catkin_LIBRARIES}
-  # ${PCL_LIBRARIES}
+  ${PCL_LIBRARIES}
   # -ldw
   )


### PR DESCRIPTION
When I try to build this repository, it throws the following error:
```bash
Errors     << exploration_manager:make /catkin_ws/logs/exploration_manager/build.make.007.log                   
/usr/bin/ld: CMakeFiles/exploration_node.dir/src/perception_aware_exploration_manager.cpp.o: undefined reference to symbol '_ZNK3pcl11KdTreeFLANNINS_8PointXYZEN5flann9L2_SimpleIfEEE12radiusSearchERKS1_dRSt6vectorIiSaIiEERS8_IfSaIfEEj'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpcl_segmentation.so.1.10: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/exploration_node.dir/build.make:155: /catkin_ws/devel/.private/exploration_manager/lib/exploration_manager/exploration_node] Error 1
make[1]: *** [CMakeFiles/Makefile2:926: CMakeFiles/exploration_node.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
cd /catkin_ws/build/exploration_manager; catkin build --get-env exploration_manager | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -
```
It turns out that the PCL_LIBRARIES is not added to target_link_libraries. It is fixed in this commit.